### PR TITLE
Updating libpython.so location on OSX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo make install-lib

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
+PATH=$PATH:/usr/local/opt/sphinx-doc/bin
+make
 sudo make install-lib

--- a/install_dependencies_osx.sh
+++ b/install_dependencies_osx.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+brew install sphinx-doc

--- a/src/setup.py
+++ b/src/setup.py
@@ -30,7 +30,10 @@ if not os.environ.has_key("Py_DEBUG"):
 else:
   Py_DEBUG = [('Py_DEBUG',1)]
 
-libpython_so = distutils.sysconfig.get_config_var('INSTSONAME')
+libpython_so = os.path.join(
+  distutils.sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX'),
+  distutils.sysconfig.get_config_var('INSTSONAME'))
+  
 ext_modules = [
     Extension(
       "pam_python",


### PR DESCRIPTION
Previous build file did not incorporate the framework directory.  Fixed the path so that the module will actually be able to dynamically load the python.so file.
